### PR TITLE
Add user_type to login response and frontend display

### DIFF
--- a/backend/controller.py
+++ b/backend/controller.py
@@ -149,12 +149,17 @@ def login():
         user = User.auth(session, required_data['email'], required_data['password'])
 
         if user:
-            # Generate a JWT token for the user upon successful login
             user_id = user.get_id()
+            user_type = user.get_type()  # Grab the user_type from the User object
             token = create_access_token(identity=f'{user_id}')
-            return {'token': token}, 200
+
+            return {
+                'token': token,
+                'user_type': user_type
+            }, 200
 
         return {'error': 'invalid_credentials'}, 401
+
 
 # ----------------------- 
 # ✅ Get Profile 

--- a/frontend/src/EventsTable.js
+++ b/frontend/src/EventsTable.js
@@ -81,43 +81,52 @@ export default function EventsTable({
       {/* Pagination Controls */}
       {hasEvents && (
         <div className="flex justify-start items-center mt-6 space-x-2">
+          {/* Previous Button */}
           <button
             onClick={() => setCurrentPage((prev) => Math.max(prev - 1, 1))}
-            className={`py-2 px-4 rounded-lg ${
-              currentPage === 1
-                ? "bg-gray-300 text-gray-500 cursor-not-allowed"
-                : "bg-gray-300 text-gray-700"
-            }`}
+            className={`py-2 px-4 rounded-lg transition-all duration-300 border
+              ${
+                currentPage === 1
+                  ? "bg-gray-300 text-gray-500 cursor-not-allowed"
+                  : "bg-gray-300 text-gray-700 hover:bg-black hover:text-white hover:scale-105 hover:shadow-md"
+              }
+            `}
             disabled={currentPage === 1}
           >
             Previous
           </button>
 
+          {/* Page Numbers */}
           <div className="flex space-x-2">
             {Array.from({ length: totalPages }, (_, i) => i + 1).map((num) => (
               <button
                 key={num}
                 onClick={() => setCurrentPage(num)}
-                className={`py-2 px-4 rounded-lg ${
-                  num === currentPage
-                    ? "bg-black text-white"
-                    : "bg-gray-300 text-gray-700"
-                }`}
+                className={`py-2 px-4 rounded-lg transition-all duration-300 border
+                  ${
+                    num === currentPage
+                      ? "bg-black text-white"
+                      : "bg-gray-300 text-gray-700 hover:bg-black hover:text-white hover:scale-105 hover:shadow-md"
+                  }
+                `}
               >
                 {num}
               </button>
             ))}
           </div>
 
+          {/* Next Button */}
           <button
             onClick={() =>
               setCurrentPage((prev) => Math.min(prev + 1, totalPages))
             }
-            className={`py-2 px-4 rounded-lg ${
-              currentPage === totalPages
-                ? "bg-gray-300 text-gray-500 cursor-not-allowed"
-                : "bg-gray-300 text-gray-700"
-            }`}
+            className={`py-2 px-4 rounded-lg transition-all duration-300 border
+              ${
+                currentPage === totalPages
+                  ? "bg-gray-300 text-gray-500 cursor-not-allowed"
+                  : "bg-gray-300 text-gray-700 hover:bg-black hover:text-white hover:scale-105 hover:shadow-md"
+              }
+            `}
             disabled={currentPage === totalPages}
           >
             Next

--- a/frontend/src/Login.js
+++ b/frontend/src/Login.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import logo from './logo.jpg'; // Assuming you have the logo here!
+import logo from './logo.jpg';
 
 const Login = () => {
   const [email, setEmail] = useState('');
@@ -12,7 +12,7 @@ const Login = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
 
-    // Check if email and password are provided
+    // Validate input fields
     if (!email || !password) {
       setApiError('Please provide both email and password.');
       return;
@@ -25,16 +25,23 @@ const Login = () => {
         body: JSON.stringify({ email, password }),
       });
 
+      const result = await response.json();
+      console.log('result: ' + result);
       if (response.ok) {
-        const result = await response.json();
-        // Save token to local storage for authentication
+        // Save token and user_type in local storage
         localStorage.setItem("token", result.token);
-        navigate("/dashboard"); // Redirect to the dashboard after successful login
+        localStorage.setItem("user_type", result.user_type);
+
+        // Console log for verification
+        console.log("Logged in user type:", result.user_type);
+
+        // Navigate to dashboard
+        navigate("/dashboard");
       } else {
-        const result = await response.json();
         setApiError(result.error || "Login failed. Please try again.");
       }
     } catch (error) {
+      console.log("ERROR", error);
       setApiError("Something went wrong. Please try again later.");
     }
   };
@@ -67,7 +74,9 @@ const Login = () => {
           </p>
 
           {/* Error message */}
-          {apiError && <p className="text-red-500 text-xs font-medium">{apiError}</p>}
+          {apiError && (
+            <p className="text-red-500 text-xs font-medium mb-4">{apiError}</p>
+          )}
 
           <form onSubmit={handleSubmit} className="space-y-8 text-left">
             {/* Email */}

--- a/frontend/src/ProfilePage.js
+++ b/frontend/src/ProfilePage.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { ChevronLeft, Eye, EyeOff } from "lucide-react"; // For the eye icon
+import { ChevronLeft, Eye, EyeOff } from "lucide-react";
 import HeaderBar from "./HeaderBar";
 import { useNavigate } from "react-router-dom";
 
@@ -20,16 +20,17 @@ export default function ProfilePage({ onBack }) {
     email: "",
   });
 
-  // States for password visibility toggles
   const [showCurrentPassword, setShowCurrentPassword] = useState(false);
   const [showNewPassword, setShowNewPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
-  // Separate status for profile and password update
-  const [updateStatus, setUpdateStatus] = useState(""); // For profile and password update status
-  const [updateError, setUpdateError] = useState(""); // For storing backend error messages
+  const [updateStatus, setUpdateStatus] = useState("");
+  const [updateError, setUpdateError] = useState("");
 
   const navigate = useNavigate();
+
+  // ✅ Get the user type from localStorage
+  const userType = localStorage.getItem("user_type");
 
   useEffect(() => {
     const fetchUserData = async () => {
@@ -55,7 +56,6 @@ export default function ProfilePage({ onBack }) {
 
         const userData = await response.json();
 
-        // Store the initial form data separately
         setInitialFormData({
           first_name: userData.first_name,
           last_name: userData.last_name,
@@ -84,14 +84,14 @@ export default function ProfilePage({ onBack }) {
 
   const handleEditClick = () => setIsEditing(true);
   const handleCancelClick = () => {
-    // Reset the form data to the initial values
     setFormData(initialFormData);
     setIsEditing(false);
   };
-  
+
   const handleProfileUpdate = async () => {
     console.log("Changes confirmed:", formData);
     setIsEditing(false);
+
     try {
       const token = localStorage.getItem("token");
       const response = await fetch("http://localhost:5003/update_profile", {
@@ -132,7 +132,6 @@ export default function ProfilePage({ onBack }) {
   const handleConfirmPasswordChange = async () => {
     console.log("Submitting password change:", formData);
 
-    // Reset error message
     setUpdateError("");
 
     if (formData.newPassword !== formData.confirmPassword) {
@@ -169,7 +168,6 @@ export default function ProfilePage({ onBack }) {
       setUpdateStatus("success");
       setIsChangingPassword(false);
 
-      // Auto-hide success/error message after 3 seconds
       setTimeout(() => {
         setUpdateStatus("");
         setUpdateError("");
@@ -179,7 +177,6 @@ export default function ProfilePage({ onBack }) {
     }
   };
 
-  // Toggle visibility for password fields
   const toggleCurrentPassword = () => setShowCurrentPassword(!showCurrentPassword);
   const toggleNewPassword = () => setShowNewPassword(!showNewPassword);
   const toggleConfirmPassword = () => setShowConfirmPassword(!showConfirmPassword);
@@ -194,14 +191,14 @@ export default function ProfilePage({ onBack }) {
             label: "LOGOUT",
             onClick: () => {
               localStorage.removeItem("token");
+              localStorage.removeItem("user_type");
               navigate("/login");
             },
           },
         ]}
       />
-      {/* MAIN CONTENT */}
+
       <div className="px-16 py-8 flex flex-col">
-        {/* BACK BUTTON & TITLE */}
         <div className="flex items-center space-x-4 mb-8">
           <button onClick={onBack} className="p-2">
             <ChevronLeft className="w-7 h-7" />
@@ -209,16 +206,13 @@ export default function ProfilePage({ onBack }) {
           <h1 className="text-4xl font-bold uppercase">My Profile</h1>
         </div>
 
-        {/* PROFILE CARD */}
         <div className="border border-black rounded-lg p-12 w-[600px] mx-auto">
-          {/* Avatar (Top Left) */}
           <div className="flex items-start">
             <div className="w-20 h-20 rounded-full bg-gray-200 flex items-center justify-center">
               <span className="text-gray-500 text-4xl">👤</span>
             </div>
           </div>
 
-          {/* Form Fields (Two per Row) */}
           <div className="mt-6 grid grid-cols-2 gap-6">
             {Object.keys(formData).map((key) => {
               if (
@@ -242,10 +236,10 @@ export default function ProfilePage({ onBack }) {
                   </div>
                 );
               }
+              return null;
             })}
           </div>
 
-          {/* Password Change Section */}
           {isChangingPassword && (
             <div className="mt-6">
               <div className="flex flex-col">
@@ -266,6 +260,7 @@ export default function ProfilePage({ onBack }) {
                   </span>
                 </div>
               </div>
+
               <div className="flex flex-col mt-4">
                 <label className="text-sm text-gray-700">New Password</label>
                 <div className="relative">
@@ -284,6 +279,7 @@ export default function ProfilePage({ onBack }) {
                   </span>
                 </div>
               </div>
+
               <div className="flex flex-col mt-4">
                 <label className="text-sm text-gray-700">Confirm New Password</label>
                 <div className="relative">
@@ -302,6 +298,7 @@ export default function ProfilePage({ onBack }) {
                   </span>
                 </div>
               </div>
+
               <div className="flex justify-end mt-4 space-x-4">
                 <button
                   className="py-2 px-6 bg-gray-300 text-black font-medium border border-gray-500 transition hover:bg-gray-400"
@@ -319,7 +316,6 @@ export default function ProfilePage({ onBack }) {
             </div>
           )}
 
-          {/* Display Status (Success/Error Message) */}
           {updateStatus && (
             <div
               className={`mt-4 ${updateStatus === "success" ? "text-green-500" : "text-red-500"}`}
@@ -330,7 +326,6 @@ export default function ProfilePage({ onBack }) {
             </div>
           )}
 
-          {/* Action Buttons */}
           {!isChangingPassword && (
             <div className="flex justify-end mt-6 space-x-4">
               {isEditing ? (
@@ -371,7 +366,7 @@ export default function ProfilePage({ onBack }) {
 
       {/* FOOTER */}
       <footer className="text-sm text-gray-600 p-4 pl-6 absolute bottom-0 left-0">
-        LOGGED IN AS: ATTENDEE
+        LOGGED IN AS: {userType ? userType.toUpperCase() : "UNKNOWN"}
       </footer>
     </div>
   );

--- a/frontend/src/attendee/CalendarView.js
+++ b/frontend/src/attendee/CalendarView.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import EventModal from "../EventModal";
 import HeaderBar from "../HeaderBar";
@@ -17,6 +17,7 @@ const categoryColors = {
 
 export default function CalendarView({ onBack }) {
   const navigate = useNavigate();
+
   const [eventsData, setEventsData] = useState([]);
   const [filteredEvents, setFilteredEvents] = useState([]);
   const [selectedEvent, setSelectedEvent] = useState(null);
@@ -24,6 +25,10 @@ export default function CalendarView({ onBack }) {
   const [year, setYear] = useState(2025);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+
+  // ✅ Get the user type from localStorage
+  const userType = localStorage.getItem("user_type");
+  console.log("Logged in user type:", userType);
 
   useEffect(() => {
     const fetchEvents = async () => {
@@ -63,8 +68,8 @@ export default function CalendarView({ onBack }) {
             organizer: event.organizer_name || "N/A",
             category: event.category || "N/A",
             color: categoryColor,
-            date: date,
-            time: time,
+            date,
+            time,
             sponsored: event.sponsor_name ? "Yes" : "No",
             sponsor: event.sponsor_name || "N/A",
             description: event.description,
@@ -178,6 +183,7 @@ export default function CalendarView({ onBack }) {
             label: "LOGOUT",
             onClick: () => {
               localStorage.removeItem("token");
+              localStorage.removeItem("user_type");
               navigate("/login");
             },
           },
@@ -251,7 +257,7 @@ export default function CalendarView({ onBack }) {
 
       {/* FOOTER */}
       <footer className="text-sm text-gray-600 p-4 pl-6">
-        LOGGED IN AS: ATTENDEE
+        LOGGED IN AS: {userType ? userType.toUpperCase() : "UNKNOWN"}
       </footer>
 
       {/* EVENT MODAL */}

--- a/frontend/src/attendee/EventDashboard.js
+++ b/frontend/src/attendee/EventDashboard.js
@@ -1,9 +1,9 @@
 import { useState, useEffect } from "react";
-import { ChevronLeft, ChevronRight, Calendar } from "lucide-react"; // Added icon
+import { ChevronLeft, ChevronRight, Calendar } from "lucide-react";
 import HeaderBar from "../HeaderBar";
 import { useNavigate } from "react-router-dom";
 
-// Define category colors
+// Category color mapping
 const categoryColors = {
   Technology: "bg-blue-100 text-blue-800",
   Finance: "bg-green-100 text-green-800",
@@ -14,7 +14,7 @@ const categoryColors = {
 };
 
 export default function EventDashboard() {
-  const navigate = useNavigate(); // Use navigate for navigation
+  const navigate = useNavigate();
   const days = ["yesterday", "today", "tomorrow"];
   const [dayIndex, setDayIndex] = useState(1);
   const [eventsData, setEventsData] = useState({
@@ -25,12 +25,11 @@ export default function EventDashboard() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  // Fetch events and categorize them by date
+  // Fetch events from the backend and categorize them
   const fetchEvents = async () => {
     try {
       setLoading(true);
       const token = localStorage.getItem("token");
-
       if (!token) {
         navigate("/login");
         return;
@@ -44,40 +43,43 @@ export default function EventDashboard() {
         },
       });
 
-      if (!response.ok) {
-        throw new Error("Failed to fetch events");
-      }
+      if (!response.ok) throw new Error("Failed to fetch events");
 
       const data = await response.json();
 
       const today = new Date();
-      const tomorrow = new Date(today);
-      tomorrow.setDate(today.getDate() + 1);
       const yesterday = new Date(today);
       yesterday.setDate(today.getDate() - 1);
+      const tomorrow = new Date(today);
+      tomorrow.setDate(today.getDate() + 1);
 
-      // Filter events by date
-      const eventsByDate = {
-        yesterday: [],
-        today: [],
-        tomorrow: [],
-      };
+      const formatDate = (dateObj) => dateObj.toISOString().split("T")[0];
+
+      const eventsByDate = { yesterday: [], today: [], tomorrow: [] };
 
       data.forEach((event) => {
-        const eventDate = new Date(event.start);
-        const eventDateString = eventDate.toISOString().split("T")[0];
+        const eventDateObj = new Date(event.start);
+        const eventDateStr = formatDate(eventDateObj);
 
-        // Map event categories to colors
-        const eventCategoryColor = categoryColors[event.category] || "bg-gray-200 text-gray-800"; // Default color if category is not found
+        const categoryColor =
+          categoryColors[event.category] || "bg-gray-200 text-gray-800";
 
-        const eventWithColor = { ...event, color: eventCategoryColor };
+        const time = event.start.split(" ")[1]; // Extract time part
+        const date = event.start.split(" ")[0]; // Extract date part
 
-        if (eventDateString === yesterday.toISOString().split("T")[0]) {
-          eventsByDate.yesterday.push(eventWithColor);
-        } else if (eventDateString === today.toISOString().split("T")[0]) {
-          eventsByDate.today.push(eventWithColor);
-        } else if (eventDateString === tomorrow.toISOString().split("T")[0]) {
-          eventsByDate.tomorrow.push(eventWithColor);
+        const formattedEvent = {
+          ...event,
+          color: categoryColor,
+          time,
+          date,
+        };
+
+        if (eventDateStr === formatDate(yesterday)) {
+          eventsByDate.yesterday.push(formattedEvent);
+        } else if (eventDateStr === formatDate(today)) {
+          eventsByDate.today.push(formattedEvent);
+        } else if (eventDateStr === formatDate(tomorrow)) {
+          eventsByDate.tomorrow.push(formattedEvent);
         }
       });
 
@@ -91,7 +93,7 @@ export default function EventDashboard() {
 
   useEffect(() => {
     fetchEvents();
-  }, [navigate]);
+  }, []);
 
   const handleDayChange = (direction) => {
     if (direction === "prev" && dayIndex > 0) {
@@ -104,87 +106,125 @@ export default function EventDashboard() {
   const currentDay = days[dayIndex];
 
   return (
-    <div className="min-h-screen bg-white flex flex-col">
-      {/* REUSABLE HEADER WITH MENU OPTIONS */}
-       <HeaderBar
-         menuOptions={[ 
-           { label: "EVENTS", onClick: () => navigate("/events") }, 
-           { label: "PROFILE", onClick: () => navigate("/profile") }, 
-           { label: "LOGOUT", onClick: () => { localStorage.removeItem("token"); navigate("/login"); } }
-         ]}
-       />
+    <div className="min-h-screen bg-white flex flex-col font-sans relative">
+      {/* HEADER BAR */}
+      <HeaderBar
+        menuOptions={[
+          { label: "EVENTS", onClick: () => navigate("/events") },
+          { label: "PROFILE", onClick: () => navigate("/profile") },
+          {
+            label: "LOGOUT",
+            onClick: () => {
+              localStorage.removeItem("token");
+              navigate("/login");
+            },
+          },
+        ]}
+      />
 
       {/* MAIN CONTENT */}
-      <div className="flex flex-grow items-center justify-center px-20 py-12">
-        <div className="w-full max-w-6xl flex">
-          {/* LEFT SECTION (Equal Width) */}
-          <div className="w-1/2 flex items-center justify-center">
-            <h1 className="text-9xl font-bold">SEES</h1>
+      <div className="flex flex-grow items-center justify-center px-6 py-10 bg-gray-50">
+        <div className="w-full max-w-6xl grid grid-cols-1 md:grid-cols-2 gap-12">
+          {/* LEFT SIDE - SEES LOGO */}
+          <div className="flex items-center justify-center">
+            <h1 className="text-9xl font-extrabold text-gray-800 tracking-tight hover:text-black transition-all duration-300">
+              SEES
+            </h1>
           </div>
 
-          {/* RIGHT SECTION (Equal Width) */}
-          <div className="w-1/2 flex flex-col items-center">
+          {/* RIGHT SIDE - EVENTS */}
+          <div className="flex flex-col items-center">
             {/* DAY NAVIGATION */}
-            <div className="flex items-center justify-center mb-8 space-x-6">
+            <div className="flex items-center mb-6 space-x-6">
               <button
                 onClick={() => handleDayChange("prev")}
                 disabled={dayIndex === 0}
-                className={`p-2 ${dayIndex === 0 ? "opacity-50 cursor-not-allowed" : ""}`}
+                className={`p-2 rounded-full transition duration-300 ${
+                  dayIndex === 0
+                    ? "cursor-not-allowed opacity-40"
+                    : "hover:bg-gray-200"
+                }`}
               >
                 <ChevronLeft className="w-6 h-6" />
               </button>
-              <h2 className="text-2xl font-semibold uppercase">{currentDay}</h2>
+
+              <h2 className="text-xl md:text-2xl font-semibold uppercase tracking-wide text-gray-800">
+                {currentDay}
+              </h2>
+
               <button
                 onClick={() => handleDayChange("next")}
                 disabled={dayIndex === days.length - 1}
-                className={`p-2 ${dayIndex === days.length - 1 ? "opacity-50 cursor-not-allowed" : ""}`}
+                className={`p-2 rounded-full transition duration-300 ${
+                  dayIndex === days.length - 1
+                    ? "cursor-not-allowed opacity-40"
+                    : "hover:bg-gray-200"
+                }`}
               >
                 <ChevronRight className="w-6 h-6" />
               </button>
             </div>
 
             {/* EVENTS LIST */}
-            <div className="w-full max-w-md space-y-3 max-h-80 overflow-y-auto">
-              {loading && <p>Loading events...</p>}
-              {error && <p className="text-red-500">{error}</p>}
+            <div className="w-full max-w-md space-y-4 max-h-80 overflow-y-auto scrollbar-thin scrollbar-thumb-gray-400 scrollbar-track-gray-100 px-2">
+              {loading && (
+                <p className="text-gray-600 text-sm">Loading events...</p>
+              )}
+
+              {error && (
+                <p className="text-red-500 text-sm">{error}</p>
+              )}
 
               {!loading && !error && eventsData[currentDay].length === 0 && (
-                <div className="bg-gray-100 p-6 rounded-lg shadow-md text-center">
-                  <Calendar className="w-16 h-16 mx-auto text-gray-500" />
-                  <p className="text-xl text-gray-700 mt-4">No events for {currentDay}.</p>
-                  <p className="text-gray-500 mt-2">Check back later for updates!</p>
+                <div className="bg-gray-100 p-6 rounded-lg shadow-md text-center animate-fadeIn">
+                  <Calendar className="w-16 h-16 mx-auto text-gray-400" />
+                  <p className="text-lg font-medium text-gray-700 mt-4">
+                    No events for {currentDay}.
+                  </p>
+                  <p className="text-sm text-gray-500 mt-1">
+                    Check back later for updates!
+                  </p>
                 </div>
               )}
 
               {!loading &&
                 !error &&
                 eventsData[currentDay].map((event, index) => (
-                  <div key={index} className="flex border rounded-lg p-4 items-center shadow-md">
-                    <div className={`w-2 h-16 ${event.color} rounded-l-lg`} />
+                  <div
+                    key={index}
+                    className="flex items-center bg-white border border-gray-200 rounded-lg shadow-sm hover:shadow-md transition-all duration-300 cursor-pointer transform hover:scale-[1.02] px-4 py-3 animate-fadeIn"
+                  >
+                    {/* Category color bar */}
+                    <div className={`w-2 h-16 ${event.color} rounded-l-md`} />
+
+                    {/* Event Info */}
                     <div className="ml-4 flex flex-col">
-                      <h3 className="font-semibold">{event.title}</h3>
-                      <p className="text-sm text-gray-600">{event.time}</p>
-                      <p className="text-xs text-gray-400">{event.category}</p>
+                      <h3 className="font-semibold text-gray-800">
+                        {event.title}
+                      </h3>
+                      <p className="text-xs text-gray-500">{event.category}</p>
+                      <p className="text-sm text-gray-600">
+                        {event.date} • {event.time}
+                      </p>
                     </div>
                   </div>
                 ))}
             </div>
 
-            <div className="mt-8">
-            <button
-  className="bg-black text-white py-2 px-8 rounded-lg transition-all duration-300 border border-black hover:bg-white hover:text-black hover:scale-105 hover:shadow-md"
-  onClick={() => navigate("/calendar")}
->
-  View Events Calendar
-</button>
-
+            {/* VIEW CALENDAR BUTTON */}
+            <div className="mt-10">
+              <button
+                onClick={() => navigate("/calendar")}
+                className="bg-black text-white py-2 px-8 rounded-lg transition-all duration-300 border border-black hover:bg-white hover:text-black hover:scale-105 hover:shadow-lg"
+              >
+                View Events Calendar
+              </button>
             </div>
           </div>
         </div>
       </div>
 
-      {/* FOOTER */}
-      <footer className="text-sm text-gray-600 p-4 pl-6">
+      <footer className="text-sm text-gray-600 p-4 pl-6 absolute bottom-0 left-0">
         LOGGED IN AS: ATTENDEE
       </footer>
     </div>

--- a/frontend/src/attendee/EventDashboard.js
+++ b/frontend/src/attendee/EventDashboard.js
@@ -25,11 +25,13 @@ export default function EventDashboard() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  // Fetch events from the backend and categorize them
+  const userType = localStorage.getItem("user_type");
+
   const fetchEvents = async () => {
     try {
       setLoading(true);
       const token = localStorage.getItem("token");
+
       if (!token) {
         navigate("/login");
         return;
@@ -116,6 +118,7 @@ export default function EventDashboard() {
             label: "LOGOUT",
             onClick: () => {
               localStorage.removeItem("token");
+              localStorage.removeItem("user_type");
               navigate("/login");
             },
           },
@@ -171,9 +174,7 @@ export default function EventDashboard() {
                 <p className="text-gray-600 text-sm">Loading events...</p>
               )}
 
-              {error && (
-                <p className="text-red-500 text-sm">{error}</p>
-              )}
+              {error && <p className="text-red-500 text-sm">{error}</p>}
 
               {!loading && !error && eventsData[currentDay].length === 0 && (
                 <div className="bg-gray-100 p-6 rounded-lg shadow-md text-center animate-fadeIn">
@@ -225,7 +226,7 @@ export default function EventDashboard() {
       </div>
 
       <footer className="text-sm text-gray-600 p-4 pl-6 absolute bottom-0 left-0">
-        LOGGED IN AS: ATTENDEE
+        LOGGED IN AS: {userType ? userType.toUpperCase() : "UNKNOWN"}
       </footer>
     </div>
   );

--- a/frontend/src/attendee/EventsPage.js
+++ b/frontend/src/attendee/EventsPage.js
@@ -19,6 +19,7 @@ const categoryColors = {
 
 export default function EventsPage({ onBack }) {
   const navigate = useNavigate();
+
   const [eventsData, setEventsData] = useState([]);
   const [filteredEvents, setFilteredEvents] = useState([]);
   const [registeredEvents, setRegisteredEvents] = useState([]);
@@ -31,6 +32,10 @@ export default function EventsPage({ onBack }) {
   const [selectedDate, setSelectedDate] = useState("");
   const [selectedTime, setSelectedTime] = useState("");
   const [viewingRegistrations, setViewingRegistrations] = useState(false);
+
+  // ✅ Retrieve user type from local storage
+  const userType = localStorage.getItem("user_type");
+  console.log("Logged in user type:", userType);
 
   const resetFilters = () => {
     setSelectedCategory("");
@@ -64,7 +69,8 @@ export default function EventsPage({ onBack }) {
         }
 
         const data = await response.json();
-        console.log(data);
+        console.log("Fetched Events:", data);
+
         const mappedEvents = data.map((event) => {
           const start = event.start;
           const date = start ? start.split(" ")[0] : "N/A";
@@ -77,9 +83,9 @@ export default function EventsPage({ onBack }) {
             title: event.title,
             organizer: event.organizer_name || "N/A",
             category: event.category || "N/A",
-            categoryColor: categoryColor,
-            date: date,
-            time: time,
+            categoryColor,
+            date,
+            time,
             sponsored: event.sponsor_name ? "Yes" : "No",
             sponsor: event.sponsor_name || "N/A",
             organizer_name: event.organizer_name,
@@ -159,6 +165,7 @@ export default function EventsPage({ onBack }) {
       }
 
       const registeredEvents = await response.json();
+
       const mappedRegisteredEvents = registeredEvents.map((event) => {
         const start = event.start;
         const date = start ? start.split(" ")[0] : "N/A";
@@ -171,9 +178,9 @@ export default function EventsPage({ onBack }) {
           title: event.title,
           organizer: event.organizer_name || "N/A",
           category: event.category || "N/A",
-          categoryColor: categoryColor,
-          date: date,
-          time: time,
+          categoryColor,
+          date,
+          time,
           sponsored: event.sponsor_name ? "Yes" : "No",
           sponsor: event.sponsor_name || "N/A",
           organizer_name: event.organizer_name,
@@ -268,6 +275,7 @@ export default function EventsPage({ onBack }) {
             label: "LOGOUT",
             onClick: () => {
               localStorage.removeItem("token");
+              localStorage.removeItem("user_type");
               navigate("/login");
             },
           },
@@ -328,7 +336,7 @@ export default function EventsPage({ onBack }) {
       )}
 
       <footer className="text-sm text-gray-600 p-4 pl-6 absolute bottom-0 left-0">
-        LOGGED IN AS: ATTENDEE
+        LOGGED IN AS: {userType ? userType.toUpperCase() : "UNKNOWN"}
       </footer>
     </div>
   );

--- a/frontend/src/attendee/EventsPage.js
+++ b/frontend/src/attendee/EventsPage.js
@@ -64,6 +64,7 @@ export default function EventsPage({ onBack }) {
         }
 
         const data = await response.json();
+        console.log(data);
         const mappedEvents = data.map((event) => {
           const start = event.start;
           const date = start ? start.split(" ")[0] : "N/A";


### PR DESCRIPTION
### Summary
- Added support for `user_type` in backend login response.
- Stored `user_type` in `localStorage` on the frontend after login.
- Displayed `user_type` dynamically in the footer across all pages.
- Cleared `user_type` from `localStorage` on logout.

### Backend Changes
- `/login` endpoint now returns both `token` and `user_type`.

### Frontend Changes
- Saved `user_type` in `localStorage` after login.
- Retrieved and displayed `user_type` in footers (EventDashboard, EventsPage, CalendarView, ProfilePage).
- Removed `user_type` from `localStorage` on logout.
